### PR TITLE
Add label updates. (vibe-kanban)

### DIFF
--- a/client/src/components/MediaDetails.svelte
+++ b/client/src/components/MediaDetails.svelte
@@ -43,6 +43,10 @@
     });
   }
   
+  // Call cleanup when component is destroyed
+  import { onDestroy } from 'svelte';
+  onDestroy(cleanup);
+  
   function addLabel() {
     if (newLabel.trim() && !labels.includes(newLabel.trim())) {
       labels = [...labels, newLabel.trim()];

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -43,16 +43,22 @@ export async function fetchTranscriptionStatus(): Promise<TranscriptionStatus[]>
  */
 export async function updateLabels(id: string, labels: string[]): Promise<MediaItem | null> {
   try {
-    // In a real implementation, this would be a PUT or PATCH request
-    // For now, we'll just return a mock response
-    return {
-      id,
-      labels,
-      type: 'photo', // This would come from the server in a real implementation
-      timestamp: new Date().toISOString(),
-      filename: 'mock.jpg',
-      transcription: ''
-    };
+    const response = await fetch('/api/labels/update', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        id,
+        labels
+      })
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to update labels: ${response.statusText}`);
+    }
+
+    return await response.json();
   } catch (error) {
     console.error('Error updating labels:', error);
     return null;

--- a/data/timeline.json
+++ b/data/timeline.json
@@ -1,0 +1,21 @@
+[
+  {
+    "id": "1",
+    "content": "Sample Audio",
+    "start": "2023-01-01",
+    "type": "audio"
+  },
+  {
+    "id": "2",
+    "content": "Sample Video",
+    "start": "2023-01-02",
+    "end": "2023-01-03",
+    "type": "video"
+  },
+  {
+    "id": "3",
+    "content": "Sample Image",
+    "start": "2023-01-04",
+    "type": "image"
+  }
+]

--- a/server/main.go
+++ b/server/main.go
@@ -72,12 +72,9 @@ const (
 	mdExt = ".md"
 )
 
-
 func main() {
 	// Ensure data directories exist
 	ensureDirectories()
-
-
 
 	// Initialize transcription system
 	InitTranscriptionSystem()
@@ -88,6 +85,7 @@ func main() {
 	http.HandleFunc("/api/metadata/", handleMetadata)
 	http.HandleFunc("/api/media", handleMedia)
 	http.HandleFunc("/api/transcription/status", handleTranscriptionStatus)
+	http.HandleFunc("/api/labels/update", handleUpdateLabels)
 
 	// Serve media files
 	http.HandleFunc("/media/", handleMediaFiles)
@@ -598,4 +596,99 @@ func handleTranscriptionStatus(w http.ResponseWriter, r *http.Request) {
 	// Return as JSON
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(statuses)
+}
+
+// UpdateLabelsRequest represents the request body for updating labels
+type UpdateLabelsRequest struct {
+	ID     string   `json:"id"`
+	Labels []string `json:"labels"`
+}
+
+// Handler for updating labels API
+func handleUpdateLabels(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Parse request body
+	var req UpdateLabelsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// Validate required fields
+	if req.ID == "" {
+		http.Error(w, "ID is required", http.StatusBadRequest)
+		return
+	}
+
+	// Find the metadata file by ID
+	// We need to search through all metadata files to find the one with matching ID
+	files, err := os.ReadDir(metadataDir)
+	if err != nil {
+		http.Error(w, "Failed to read metadata directory", http.StatusInternalServerError)
+		return
+	}
+
+	var targetFile string
+	var metadata MediaMetadata
+	for _, file := range files {
+		if !file.IsDir() && strings.HasSuffix(file.Name(), mdExt) {
+			filePath := filepath.Join(metadataDir, file.Name())
+
+			var tempMetadata MediaMetadata
+			content, readErr := readMarkdownFile(filePath, &tempMetadata)
+			if readErr != nil {
+				log.Printf("Failed to read metadata file %s: %v", file.Name(), readErr)
+				continue
+			}
+
+			if tempMetadata.ID == req.ID {
+				targetFile = filePath
+				metadata = tempMetadata
+				metadata.Transcription = content
+				break
+			}
+		}
+	}
+
+	if targetFile == "" {
+		http.Error(w, "Media item not found", http.StatusNotFound)
+		return
+	}
+
+	// Update the labels
+	metadata.Labels = req.Labels
+
+	// Create frontmatter data for writing
+	frontmatterData := struct {
+		ID        string   `yaml:"id"`
+		Filename  string   `yaml:"filename"`
+		Path      string   `yaml:"path"`
+		Type      string   `yaml:"type"`
+		Timestamp string   `yaml:"timestamp"`
+		Duration  float64  `yaml:"duration,omitempty"`
+		Labels    []string `yaml:"labels"`
+	}{
+		ID:        metadata.ID,
+		Filename:  metadata.Filename,
+		Path:      metadata.Path,
+		Type:      metadata.Type,
+		Timestamp: metadata.Timestamp,
+		Duration:  metadata.Duration,
+		Labels:    metadata.Labels,
+	}
+
+	// Write the updated metadata back to the file
+	if err := writeMarkdownFile(targetFile, frontmatterData, metadata.Transcription); err != nil {
+		log.Printf("Error updating metadata file %s: %v", targetFile, err)
+		http.Error(w, "Failed to update labels", http.StatusInternalServerError)
+		return
+	}
+
+	// Return the updated metadata
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(metadata)
 }

--- a/server/main.go
+++ b/server/main.go
@@ -467,6 +467,11 @@ func handleMetadata(w http.ResponseWriter, r *http.Request) {
 				}
 				metadata.Transcription = content
 
+				// Ensure Labels is never nil
+				if metadata.Labels == nil {
+					metadata.Labels = []string{}
+				}
+
 				allMetadata = append(allMetadata, metadata)
 			}
 		}
@@ -498,6 +503,11 @@ func handleMetadata(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	metadata.Transcription = content
+
+	// Ensure Labels is never nil
+	if metadata.Labels == nil {
+		metadata.Labels = []string{}
+	}
 
 	// Marshal the metadata
 	responseData, marshalErr := json.Marshal(metadata)
@@ -552,6 +562,11 @@ func handleMedia(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 			metadata.Transcription = content
+
+			// Ensure Labels is never nil
+			if metadata.Labels == nil {
+				metadata.Labels = []string{}
+			}
 
 			allMetadata = append(allMetadata, metadata)
 		}

--- a/server/transcription.go
+++ b/server/transcription.go
@@ -423,7 +423,7 @@ func updateMetadataWithTranscript(filename, transcriptPath string) error {
 	// Read the Markdown file with frontmatter
 	metadataPathMd := filepath.Join(metadataDir, filename+mdExt)
 	var metadata MediaMetadata
-	_, err := readMarkdownFile(metadataPathMd, &metadata)
+	_, err = readMarkdownFile(metadataPathMd, &metadata)
 	if err != nil {
 		return fmt.Errorf("failed to read metadata file: %v", err)
 	}


### PR DESCRIPTION
In the media details pane in client/src/components/MediaDetails.svelte  when the labels are updated on the client side we need to send a request on the server side to update the labels in the metadata markdown files. Update the server/main.go file to have a function and api that the client calls to update the labels of a media event. 